### PR TITLE
Update Chrome info.

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,10 @@ code {
       <ol>
         <li>Save the Appchan X file from the install button as <code>appchan_x.user.js</code>.</li>
         <li>Drag and drop the file into the extensions page (<code>chrome://chrome/extensions/</code>).</li>
+        <ul>
+          <li>If a Windows user, adding <code>--enable-easy-off-store-extension-install</code> to Chrome's target flag will restore the old install functionality.</li>
+          <li>Make sure the filename is not saved as <code>4chan_x(1).user.js</code> or similar or Chrome might just resave the file instead of installing it.</li>
+        </ul>
       </ol>
 
       <b class=firefox>Firefox</b>:


### PR DESCRIPTION
Added a note to help Chrome users install 4chan X. The first note will restore click-to-install functionality, and the second will help those who can't do that and are having problems.
