### PR TITLE
Fix for images appearing above page/board navigation and textarea font

### DIFF
--- a/src/style.coffee
+++ b/src/style.coffee
@@ -232,7 +232,6 @@ h1,
   box-sizing: border-box;
   """ + agent + """box-sizing: border-box;
   color: #333;
-  font: 13px sans-serif;
   margin: 0;
   padding: 2px 4px 3px;
   """ + agent + """transition: color .25s, border .25s;


### PR DESCRIPTION
The commits add a z-index to the thread container, which forces the images below the page and board navigation (if active). this also apparently fixed an issue with some images appearing partially loaded under certain circumstances.
The commits also remove the font declaration for the quick reply, allowing the user-defined font to control those elements.
