### PR TITLE
Additional Cooldown Setting

### DIFF
--- a/src/General/Config.coffee
+++ b/src/General/Config.coffee
@@ -1135,3 +1135,5 @@ box-shadow: inset 2px 2px 2px rgba(0,0,0,0.2);
   'theme_sfw':  'Yotsuba B'
   'theme_nsfw': 'Yotsuba'
   mascot : ''
+
+  additionalCooldown: 0

--- a/src/General/Settings.coffee
+++ b/src/General/Settings.coffee
@@ -232,7 +232,7 @@ Settings =
     section.innerHTML = <%= importHTML('Settings/Advanced') %>
     items = {}
     inputs = {}
-    for name in ['boardnav', 'time', 'backlink', 'fileInfo', 'favicon', 'usercss']
+    for name in ['boardnav', 'time', 'backlink', 'fileInfo', 'favicon', 'usercss', 'additionalCooldown']
       input = $ "[name='#{name}']", section
       items[name]  = Conf[name]
       inputs[name] = input
@@ -252,7 +252,7 @@ Settings =
       for key, val of items
         input = inputs[key]
         input.value = val
-        continue if key is 'usercss'
+        continue if key is 'usercss' or 'additionalCooldown'
         $.on input, event, Settings[key]
         Settings[key].call input
       Rice.nodes section

--- a/src/General/html/Settings/Advanced.html
+++ b/src/General/html/Settings/Advanced.html
@@ -102,6 +102,13 @@
 </fieldset>
 
 <fieldset>
+  <legend>Additional Cooldown Time</legend>
+  <div>
+    Seconds: <input type=number name=additionalCooldown class=field min=1 value=#{Conf['additionalCooldown']}>
+  </div>
+</fieldset>
+
+<fieldset>
   <legend><input type=checkbox name='Custom CSS' #{if Conf['Custom CSS'] then 'checked' else ''}> Custom CSS</legend>
   <div>
     <button id=apply-css>Apply CSS</button>

--- a/src/Posting/QR.cooldown.coffee
+++ b/src/Posting/QR.cooldown.coffee
@@ -6,7 +6,7 @@ QR.cooldown =
     $.globalEval 'window.dispatchEvent(new CustomEvent("cooldown:timers", {detail: cooldowns}))'
     $.off window, 'cooldown:timers', setTimers
     for type of QR.cooldown.types
-      QR.cooldown.types[type] = +QR.cooldown.types[type]
+      QR.cooldown.types[type] = +QR.cooldown.types[type] + parseInt(Conf['additionalCooldown'])
     key = "cooldown.#{g.BOARD}"
     $.get key, {}, (item) ->
       QR.cooldown.cooldowns = item[key]


### PR DESCRIPTION
When multiple posts are queued up it is sometimes unwanted for them to dump as fast as the board allows.
This adds an option under the Advanced Settings pane to add a configurable amount of seconds to the posting cooldown.
