### PR TITLE
Add thread subject-matching support to personas.

### DIFF
--- a/src/General/html/Settings/Advanced.html
+++ b/src/General/html/Settings/Advanced.html
@@ -78,10 +78,17 @@
     Lines starting with a <code>#</code> will be ignored.
   </p>
   <ul>You can use these settings with each item, separate them with semicolons:
-    <li>Possible items are: <code>name</code>, <code>options</code> (or equivalently <code>email</code>), <code>subject</code> and <code>password</code>.</li>
-    <li>Wrap values of items with quotes, like this: <code>options:"sage"</code>.</li>
+    <li>Possible fields are: <code>name</code>, <code>options</code> (or equivalently <code>email</code>), <code>subject</code> and <code>password</code>.</li>
+    <li>Wrap values of fields with quotes, like this: <code>options:"sage"</code>.</li>
     <li>Force values as defaults with the <code>always</code> keyword, for example: <code>options:"sage";always</code>.</li>
-    <li>Select specific boards for an item, separated with commas, for example: <code>options:"sage";boards:jp;always</code>.</li>
+    <li>Possible match fields:
+      <dl>
+        <dt><code>threads:/regex/,string,...</code></dt>
+        <dd>Match on thread subject.  Accepts a list of regular expressions or strings, only one has to match to activate the persona (think OR logic). Great for matching /vg/ generals.</dd>
+        <dt><code>boards:a,b,...</code></dt>
+        <dd>Make your persona board-specific.  Matches board IDs <em>without</em> slashes, and only one has to match to activate the persona.</dd>
+      </dl>
+    </li>
   </ul>
 </fieldset>
 


### PR DESCRIPTION
# Usecase

Users frequently post in several threads on 4chan, sometimes using one tripcode per thread.  Other users who normally use a tripcode in one thread may opt to post anonymously in another.  

As someone who had to post in an official capacity in KSPG while posting anonymously in other threads, it was quickly becoming annoying having to ensure that one thread had a tripcode enabled, while others were set to anonymous posting.

# Changes
 * Added `threads:` directive to Personas, which takes a list of `/regex/` or `strings` and matches those against the thread subject field.
 * Added documentation for `threads:`.
 * Clarified existing documentation for Personas.

# Test script

1. Add the following rules to Personas:
 * `name:"In /egg/ thread";boards:vg;threads:/\begg\b/;always`
 * `name:"In /ss13g/ thread";boards:vg;threads:/\bss13g\b/;always`
2. Load up /egg/ and /ss13g/ from /vg/
3. Verify that your name is set to "In /egg/ thread" in /egg/
4. Verify that your name is set to "In /ss13g/ thread" in /ss13g/

# Other Notes

New-ish to CoffeeScript, please be gentle.