### PR TITLE
IP count suffix fix

### DIFF
--- a/src/Monitoring/MarkNewIPs.coffee
+++ b/src/Monitoring/MarkNewIPs.coffee
@@ -32,10 +32,10 @@ MarkNewIPs =
     MarkNewIPs.postIDs = postIDs
 
   markNew: (post, ipCount) ->
-    suffix = if (ipCount // 10) % 10 is 1
+    suffix = if (ipCount // 10) % 10 is 1 || if (ipCount % 10) is 0
       'th'
     else
-      ['st', 'nd', 'rd'][ipCount % 10 - 1] or 'th' # fuck switches
+      ['st', 'nd', 'rd'][ipCount % 10] or 'th'
     counter = $.el 'span',
       className: 'ip-counter'
       textContent: "(#{ipCount})"

--- a/src/Monitoring/MarkNewIPs.coffee
+++ b/src/Monitoring/MarkNewIPs.coffee
@@ -35,7 +35,7 @@ MarkNewIPs =
     suffix = if (ipCount // 10) % 10 is 1 || if (ipCount % 10) is 0
       'th'
     else
-      ['st', 'nd', 'rd'][ipCount % 10] or 'th'
+      ['st', 'nd', 'rd'][ipCount % 10 - 1] or 'th'
     counter = $.el 'span',
       className: 'ip-counter'
       textContent: "(#{ipCount})"


### PR DESCRIPTION
I'm not too familiar with CoffeeScript syntax but it looks like this change should fix the IP counting suffix when the count is evenly divisible by 10. 