### PR TITLE
Fix Chrome navigation bug

### DIFF
--- a/src/General/Navigate.coffee
+++ b/src/General/Navigate.coffee
@@ -3,17 +3,7 @@ Navigate =
   init: ->
     return unless Conf['JSON Navigation'] and g.VIEW in ['index', 'thread'] and g.BOARD.ID isnt 'f'
 
-    <% if (type === 'crx') { %>
-    # blink/webkit throw a popstate on page load. Not what we want.
-    popstateHack = ->
-      $.off window, 'popstate', popstateHack
-      $.on  window, 'popstate', Navigate.popstate
-
-    $.on window, 'popstate', popstateHack
-    <% } else { %>
     $.on  window, 'popstate', Navigate.popstate
-    <% } %>
-
     $.ready ->
       Navigate.makeBreadCrumb window.location, g.VIEW, g.BOARD.ID, g.THREADID
       $.add Index.navLinks, Navigate.el


### PR DESCRIPTION
Some time ago, Blink/WebKit had a bug which caused a popstate event to
be fired when a document was loaded the first time. This was worked
around in appchan-x by ignoring the first popstate event. Meanwhile the
browser bug has been fixed and the workaround has itself turned into a
bug. This commit removes the workaround.

Upstream issue:
https://code.google.com/p/chromium/issues/detail?id=63040

Closes #885
Closes #829
Closes #934